### PR TITLE
Added validate to the cmd options for viz.

### DIFF
--- a/packages/dscc-scripts/src/args.ts
+++ b/packages/dscc-scripts/src/args.ts
@@ -109,6 +109,7 @@ export enum VizScripts {
   BUILD = 'build',
   PUSH = 'push',
   UPDATE_MESSAGE = 'update_message',
+  VALIDATE = 'validate',
 }
 
 export enum MessageFormat {
@@ -125,6 +126,8 @@ export interface VizArgs {
   script: VizScripts;
   deployment?: DeploymentChoices;
   format?: MessageFormat;
+  configPath?: string;
+  manifestPath?: string;
 }
 const addVizParserDetails = (subparsers: argparse.SubParser) => {
   const vizParser = subparsers.addParser(ScriptChoice.VIZ, {
@@ -140,6 +143,7 @@ const addVizParserDetails = (subparsers: argparse.SubParser) => {
   let build: argparse.ArgumentParser;
   let push: argparse.ArgumentParser;
   let updateMessage: argparse.ArgumentParser;
+  let validate: argparse.ArgumentParser;
   Object.values(VizScripts).forEach((scriptName: VizScripts) => {
     switch (scriptName) {
       case VizScripts.START:
@@ -167,6 +171,12 @@ const addVizParserDetails = (subparsers: argparse.SubParser) => {
             'Temporarily update your viz so you can copy example data from Data Studio.',
         });
         break;
+      case VizScripts.VALIDATE:
+        validate = vizSubparsers.addParser(scriptName, {
+          addHelp: true,
+          description: `Validate your viz's manifest & config files`,
+        });
+        break;
       default:
         return assertNever(scriptName);
     }
@@ -187,6 +197,18 @@ const addVizParserDetails = (subparsers: argparse.SubParser) => {
     dest: 'format',
     help: 'The format for the data.',
     required: true,
+  });
+
+  validate!.addArgument(['--configPath'], {
+    dest: 'configPath',
+    help: 'The path to your config.json file.',
+    required: false,
+  });
+
+  validate!.addArgument(['--manifestPath'], {
+    dest: 'manifestPath',
+    help: 'The path to your manifest.json file.',
+    required: false,
   });
 };
 

--- a/packages/dscc-scripts/src/viz.ts
+++ b/packages/dscc-scripts/src/viz.ts
@@ -38,7 +38,7 @@ const deploy = async (args: VizArgs): Promise<void> => {
 const validate = async (args: VizArgs): Promise<void> => {
   if (!args.configPath && !args.manifestPath) {
     throw new Error(
-      'At least one of --configPath or --manifestPast is required'
+      'At least one of --configPath or --manifestPath is required'
     );
   }
   if (args.configPath) {

--- a/packages/dscc-scripts/src/viz.ts
+++ b/packages/dscc-scripts/src/viz.ts
@@ -35,6 +35,22 @@ const deploy = async (args: VizArgs): Promise<void> => {
   console.log(`Viz deployed to: ${buildValues.gcsBucket}`);
 };
 
+const validate = async (args: VizArgs): Promise<void> => {
+  if (!args.configPath && !args.manifestPath) {
+    throw new Error(
+      'At least one of --configPath or --manifestPast is required'
+    );
+  }
+  if (args.configPath) {
+    util.validateConfigFile(args.configPath);
+    console.log(`File: ${args.configPath} is a valid config.`);
+  }
+  if (args.manifestPath) {
+    util.validateManifestFile(args.manifestPath);
+    console.log(`File: ${args.manifestPath} is a valid manifest.`);
+  }
+};
+
 export const main = async (args: VizArgs): Promise<void> => {
   switch (args.script) {
     case VizScripts.START:
@@ -47,6 +63,8 @@ export const main = async (args: VizArgs): Promise<void> => {
       await buildMessage(args);
       return deploy(args);
     }
+    case VizScripts.VALIDATE:
+      return validate(args);
     default:
       return assertNever(args.script);
   }

--- a/packages/dscc-scripts/src/viz/build.ts
+++ b/packages/dscc-scripts/src/viz/build.ts
@@ -67,8 +67,7 @@ export const build = async (args: VizArgs) => {
   const compiler = webpack(webpackOptions);
 
   const configSrc = path.resolve(process.env.PWD!, 'src', buildValues.jsonFile);
-  const configContents = await fs.readFile(configSrc, encoding);
-  util.validateConfig(configContents);
+  util.validateConfigFile(configSrc);
 
   const compilerRun = bluebird.promisify(compiler.run, {context: compiler});
 
@@ -85,10 +84,10 @@ export const build = async (args: VizArgs) => {
     buildValues.manifestFile
   );
   const manifestContents = await fs.readFile(manifestSrc, encoding);
-  util.validateManifest(manifestContents);
   const newManifest = manifestContents
     .replace(/YOUR_GCS_BUCKET/g, buildValues.gcsBucket)
     .replace(/"DEVMODE_BOOL"/, `${buildValues.devMode}`);
+  util.validateManifest(JSON.parse(newManifest));
 
   return fs.writeFile(manifestDest, newManifest);
 };


### PR DESCRIPTION
Usage:

`dscc-scripts viz validate --configPath '/path/to/config' --manifestPath '/path/to/manifest'`