### PR TITLE
fixed manifest validation

### DIFF
--- a/packages/dscc-scripts/src/viz/build.ts
+++ b/packages/dscc-scripts/src/viz/build.ts
@@ -88,6 +88,6 @@ export const build = async (args: VizArgs) => {
   const newManifest = manifestContents
     .replace(/YOUR_GCS_BUCKET/g, buildValues.gcsBucket)
     .replace(/"DEVMODE_BOOL"/, `${buildValues.devMode}`);
-  validate.validateManifest(JSON.parse(newManifest));
-  return fs.writeFile(manifestDest, newManifest);
+  await fs.writeFile(manifestDest, newManifest);
+  validate.validateManifest(JSON.parse(manifestDest));
 };


### PR DESCRIPTION
Manifest validation didn't work after merge conflicts - this should fix it & then all can be redeployed.