### PR TITLE
last bugfix

### DIFF
--- a/packages/dscc-scripts/src/viz/build.ts
+++ b/packages/dscc-scripts/src/viz/build.ts
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as validate from '@google/dscc-validation';
 import * as bluebird from 'bluebird';
 import * as CopyWebpackPlugin from 'copy-webpack-plugin';
 import * as fs from 'mz/fs';

--- a/packages/dscc-scripts/src/viz/build.ts
+++ b/packages/dscc-scripts/src/viz/build.ts
@@ -89,5 +89,5 @@ export const build = async (args: VizArgs) => {
     .replace(/YOUR_GCS_BUCKET/g, buildValues.gcsBucket)
     .replace(/"DEVMODE_BOOL"/, `${buildValues.devMode}`);
   await fs.writeFile(manifestDest, newManifest);
-  validate.validateManifest(JSON.parse(manifestDest));
+  util.validateManifestFile(manifestDest);
 };


### PR DESCRIPTION
Turns out that JSON.parse("filename") does not make for validating the right object. Whoops.