### PR TITLE
Cleaner types for configs

### DIFF
--- a/packages/ds-component/__tests__/impl.test.ts
+++ b/packages/ds-component/__tests__/impl.test.ts
@@ -684,6 +684,14 @@ test('If elements are dim met dim dim, they have to be sorted specially.', () =>
           id: 'concepts',
           elements: [
             {
+              id: 'max_results',
+              label: 'Max Results',
+              type: sut.ConfigDataElementType.MAX_RESULTS,
+              options: {
+                max: 3,
+              },
+            },
+            {
               id: 'index',
               label: 'Index Dimension',
               type: sut.ConfigDataElementType.DIMENSION,

--- a/packages/ds-component/__tests__/impl.test.ts
+++ b/packages/ds-component/__tests__/impl.test.ts
@@ -18,7 +18,6 @@ import * as sut from '../src/index';
 import {
   DSInteractionData,
   DSInteractionType,
-  Interaction,
   InteractionsById,
   InteractionType,
   ThemeStyle,
@@ -292,7 +291,6 @@ const testMessage = (
               options: {
                 min: 1,
                 max: numMetrics,
-                supportedTypes: [],
               },
               value: metricFields.map((a) => a.id),
             },

--- a/packages/ds-component/src/index.ts
+++ b/packages/ds-component/src/index.ts
@@ -274,11 +274,17 @@ export const fieldsByConfigId = (message: Message): FieldsByConfigId => {
   const fieldsBy: FieldsByConfigId = {};
 
   message.config.data.forEach((configData: ConfigData) => {
-    configData.elements.forEach((configDataElement: ConfigDataElement) => {
-      fieldsBy[configDataElement.id] = configDataElement.value.map(
-        (dsId: FieldId): Field => fieldsByDSId[dsId]
-      );
-    });
+    configData.elements
+      .filter(
+        (element) =>
+          element.type === ConfigDataElementType.DIMENSION ||
+          element.type === ConfigDataElementType.METRIC
+      )
+      .forEach((configDataElement: ConfigDataElement) => {
+        fieldsBy[configDataElement.id] = configDataElement.value.map(
+          (dsId: FieldId): Field => fieldsByDSId[dsId]
+        );
+      });
   });
 
   return fieldsBy;

--- a/packages/ds-component/src/index.ts
+++ b/packages/ds-component/src/index.ts
@@ -20,6 +20,8 @@ import {
   ConfigData,
   ConfigDataElement,
   ConfigDataElementType,
+  ConfigDataElementMetric,
+  ConfigDataElementDimension,
   ConfigId,
   ConfigStyle,
   ConfigStyleElement,
@@ -181,20 +183,23 @@ const toNum = (cdet: ConfigDataElementType) =>
  * Note: this is relying on the fact that the postMessage from DataStudio has
  * the fields sorted to be dimensions, followed by metrics.
  */
+type ConfigDataConcept = ConfigDataElementMetric | ConfigDataElementDimension;
+
 const flattenConfigIds = (message: Message): ConfigId[] => {
-  const configDataElements: ConfigDataElement[] = [];
+  const dimnsAndMets: ConfigDataConcept[] = [];
   message.config.data.forEach((configData: ConfigData) => {
-    configData.elements.forEach((configDataElement: ConfigDataElement) => {
-      configDataElements.push(configDataElement);
-    });
+    configData.elements
+      .filter(dimensionOrMetric)
+      .forEach((configDataElement: ConfigDataConcept) => {
+        dimnsAndMets.push(configDataElement);
+      });
   });
-  const dimnsAndMets = configDataElements.filter(dimensionOrMetric);
   const sorted = stableSort(
     dimnsAndMets,
     (a, b) => toNum(a.type) - toNum(b.type)
   );
   const configIds: ConfigId[] = [];
-  sorted.forEach((configDataElement: ConfigDataElement) => {
+  sorted.forEach((configDataElement) => {
     configDataElement.value.forEach(() => configIds.push(configDataElement.id));
   });
   return configIds;
@@ -275,12 +280,8 @@ export const fieldsByConfigId = (message: Message): FieldsByConfigId => {
 
   message.config.data.forEach((configData: ConfigData) => {
     configData.elements
-      .filter(
-        (element) =>
-          element.type === ConfigDataElementType.DIMENSION ||
-          element.type === ConfigDataElementType.METRIC
-      )
-      .forEach((configDataElement: ConfigDataElement) => {
+      .filter(dimensionOrMetric)
+      .forEach((configDataElement: ConfigDataConcept) => {
         fieldsBy[configDataElement.id] = configDataElement.value.map(
           (dsId: FieldId): Field => fieldsByDSId[dsId]
         );

--- a/packages/ds-component/src/types.ts
+++ b/packages/ds-component/src/types.ts
@@ -344,11 +344,11 @@ export interface ConfigDataElementMetric {
     /**
      * The minimum number of metrics supported.
      */
-    min: number;
+    min?: number;
     /**
      * The maximum number of metrics supported.
      */
-    max: number;
+    max?: number;
   };
   /**
    * The list of [[FieldId]]s selected by the user.
@@ -378,11 +378,11 @@ export interface ConfigDataElementDimension {
     /**
      * The minimum number of dimensions supported.
      */
-    min: number;
+    min?: number;
     /**
      * The maximum number of dimensions supported.
      */
-    max: number;
+    max?: number;
     supportedTypes?: Array<'TIME' | 'GEO' | 'DEFAULT'>;
   };
   /**

--- a/packages/ds-component/src/types.ts
+++ b/packages/ds-component/src/types.ts
@@ -558,36 +558,6 @@ export enum ConfigStyleElementType {
   SELECT_RADIO = 'SELECT_RADIO',
 }
 
-// export interface MetricOptions {
-//   /**
-//    * The minimum number of metrics supported.
-//    */
-//   min: number;
-//   /**
-//    * The maximum number of metrics supported.
-//    */
-//   max: number;
-// }
-
-// export interface DimensionOptions {
-//   /**
-//    * The minimum number of dimensions supported.
-//    */
-//   min: number;
-//   /**
-//    * The maximum number of dimensions supported.
-//    */
-//   max: number;
-//   supportedTypes: FieldType[];
-// }
-
-// export interface MaxResultsOptions {
-//   /**
-//    * The maximum number of rows.
-//    */
-//   max: number;
-// }
-
 export type DSInteractionData = DSInteractionFilterData;
 
 export interface DSInteractionFilterData {

--- a/packages/ds-component/src/types.ts
+++ b/packages/ds-component/src/types.ts
@@ -348,7 +348,7 @@ export interface ConfigDataElement {
    *
    * This is only defined if the [[ConfigElementType]] is `DIMENSION` or `METRIC`.
    */
-  value: FieldId[];
+  value?: FieldId[];
 }
 export interface ConfigStyleElement {
   /**

--- a/packages/ds-component/src/types.ts
+++ b/packages/ds-component/src/types.ts
@@ -322,34 +322,106 @@ export type DSRow = DSRowValue[];
  */
 export type DSRowValue = string | number | boolean;
 
-export interface ConfigDataElement {
+export interface ConfigDataElementMetric {
   /**
    * The data element type to render.
    */
-  type: ConfigDataElementType;
+  type: ConfigDataElementType.METRIC;
   /**
-   * The ID of the data element.
+   * The ID of the metric.
    *
    * This should be a non-empty string with no spaces.
    */
   id: ConfigDataElementId;
   /**
-   * The tooltip or label for the data element.
+   * The tooltip or label for the metric.
    */
   label: string;
   /**
-   * The data options for the element.
-   *
-   * This is dependent on the [[ConfigDataElementType]] of the element.
+   * The data options for a Metric.
    */
-  options: DataElementOptions;
+  options: {
+    /**
+     * The minimum number of metrics supported.
+     */
+    min: number;
+    /**
+     * The maximum number of metrics supported.
+     */
+    max: number;
+  };
   /**
    * The list of [[FieldId]]s selected by the user.
-   *
-   * This is only defined if the [[ConfigElementType]] is `DIMENSION` or `METRIC`.
    */
-  value?: FieldId[];
+  value: FieldId[];
 }
+
+export interface ConfigDataElementDimension {
+  /**
+   * The data element type to render.
+   */
+  type: ConfigDataElementType.DIMENSION;
+  /**
+   * The ID of the dimension.
+   *
+   * This should be a non-empty string with no spaces.
+   */
+  id: ConfigDataElementId;
+  /**
+   * The tooltip or label for the dimension.
+   */
+  label: string;
+  /**
+   * The data options for a Dimension.
+   */
+  options: {
+    /**
+     * The minimum number of dimensions supported.
+     */
+    min: number;
+    /**
+     * The maximum number of dimensions supported.
+     */
+    max: number;
+    supportedTypes?: Array<'TIME' | 'GEO' | 'DEFAULT'>;
+  };
+  /**
+   * The list of [[FieldId]]s selected by the user.
+   */
+  value: FieldId[];
+}
+
+export interface ConfigDataElementMaxResults {
+  /**
+   * The data element type to render.
+   */
+  type: ConfigDataElementType.MAX_RESULTS;
+  /**
+   * The ID of the max results.
+   *
+   * This should be a non-empty string with no spaces.
+   */
+  id: ConfigDataElementId;
+  /**
+   * The tooltip or label for the max results.
+   */
+  label: string;
+  /**
+   * The data options for a Max Results.
+   */
+  options: {
+    /**
+     * The maximum number of rows.
+     */
+    max: number;
+  };
+}
+
+export type ConfigDataElement =
+  | ConfigDataElementMaxResults
+  | ConfigDataElementMetric
+  | ConfigDataElementDimension;
+
 export interface ConfigStyleElement {
   /**
    * The style element type to render.
@@ -394,22 +466,10 @@ export enum ConfigDataElementType {
    */
   DIMENSION = 'DIMENSION',
   /**
-   * Renders a sort field element.
-   *
-   * Sort has an order dropdown.
-   */
-  SORT = 'SORT',
-  /**
    * Renders a dropdown that affects the maximum number of results returned.
    */
   MAX_RESULTS = 'MAX_RESULTS',
 }
-
-export type DataElementOptions =
-  | MetricOptions
-  | DimensionOptions
-  | SortOptions
-  | MaxResultsOptions;
 
 export enum ConfigStyleElementType {
   /**
@@ -498,42 +558,35 @@ export enum ConfigStyleElementType {
   SELECT_RADIO = 'SELECT_RADIO',
 }
 
-export interface MetricOptions {
-  /**
-   * The minimum number of metrics supported.
-   */
-  min: number;
-  /**
-   * The maximum number of metrics supported.
-   */
-  max: number;
-}
+// export interface MetricOptions {
+//   /**
+//    * The minimum number of metrics supported.
+//    */
+//   min: number;
+//   /**
+//    * The maximum number of metrics supported.
+//    */
+//   max: number;
+// }
 
-export interface DimensionOptions {
-  /**
-   * The minimum number of dimensions supported.
-   */
-  min: number;
-  /**
-   * The maximum number of dimensions supported.
-   */
-  max: number;
-  supportedTypes: FieldType[];
-}
+// export interface DimensionOptions {
+//   /**
+//    * The minimum number of dimensions supported.
+//    */
+//   min: number;
+//   /**
+//    * The maximum number of dimensions supported.
+//    */
+//   max: number;
+//   supportedTypes: FieldType[];
+// }
 
-export interface SortOptions {
-  /**
-   * `"DESC"` for descending, `"ASC"` for ascending.
-   */
-  defaultOrder: 'DESC' | 'ASC';
-}
-
-export interface MaxResultsOptions {
-  /**
-   * The maximum number of rows.
-   */
-  max: number;
-}
+// export interface MaxResultsOptions {
+//   /**
+//    * The maximum number of rows.
+//    */
+//   max: number;
+// }
 
 export type DSInteractionData = DSInteractionFilterData;
 


### PR DESCRIPTION
Make separate types for each config type. Typescript will be able to infer (most of the time) which type is used by doing a check against the `.type` property. 