### PR TITLE
viz-ts: support .tsx files

### DIFF
--- a/packages/dscc-gen/templates/viz-ts/webpack.config.js
+++ b/packages/dscc-gen/templates/viz-ts/webpack.config.js
@@ -36,14 +36,14 @@ module.exports = [
     module: {
       rules: [
         {
-          test: /\.ts$/,
+          test: /\.tsx?$/,
           use: 'ts-loader',
           exclude: /node_modules/,
         },
       ],
     },
     resolve: {
-      extensions: ['.ts', '.js'],
+      extensions: ['.ts', '.tsx', '.js'],
     },
   },
 ];

--- a/packages/dscc-scripts/src/viz/build.ts
+++ b/packages/dscc-scripts/src/viz/build.ts
@@ -86,14 +86,14 @@ const buildOptions = (buildValues: BuildValues): webpack.Configuration => {
       module: {
         rules: [
           {
-            test: /\.ts$/,
+            test: /\.tsx?$/,
             use: 'ts-loader',
             exclude: /node_modules/,
           },
         ],
       },
       resolve: {
-        extensions: ['.ts', '.js'],
+        extensions: ['.ts', '.tsx', '.js'],
       },
     };
     Object.assign(webpackOptions, tsOptions);


### PR DESCRIPTION
.tsx as extension in webpack config,
allows using JSX for building in visualizations.

.jsx works fine on local development (webpack server), but fails at build because:
- `build` script in this package overrides webpack config, and doesn't provide a mechanism to override the hardcoded options
- typescript doesn't allow JSX in `.ts` files (forces you to use the `.tsx` extension)
